### PR TITLE
feat: Add stream mode conditional rendering and theme-aware text color

### DIFF
--- a/components/Interface-Chatbot/ChatbotTextField.tsx
+++ b/components/Interface-Chatbot/ChatbotTextField.tsx
@@ -43,7 +43,7 @@ const ChatbotTextField: React.FC<ChatbotTextFieldProps> = ({ className, chatSess
   const fileInputRef = useRef<HTMLInputElement>(null);
   const emitTypingStatus = useTypingStatus({ chatSessionId, tabSessionId });
 
-  const { isHelloUser, mode, inbox_id, show_send_button, assigned_type } = useCustomSelector((state) => ({
+  const { isHelloUser, mode, inbox_id, show_send_button, assigned_type, isStream } = useCustomSelector((state) => ({
     isHelloUser: state.draftData?.isHelloUser || false,
     mode: state.Hello?.[chatSessionId]?.mode || [],
     inbox_id: state.Hello?.[chatSessionId]?.widgetInfo?.inbox_id,
@@ -51,6 +51,7 @@ const ChatbotTextField: React.FC<ChatbotTextFieldProps> = ({ className, chatSess
     assigned_type: state.Hello?.[chatSessionId]?.channelListData?.channels?.find(
       (channel: any) => channel?.channel === currentChannelId
     )?.assigned_type || '',
+    isStream: (state.Hello?.[chatSessionId]?.mode || []).includes('stream'),
   }));
 
   const { messageRef } = useContext(MessageContext);
@@ -88,7 +89,7 @@ const ChatbotTextField: React.FC<ChatbotTextFieldProps> = ({ className, chatSess
       sendMessageToHello?.();
       emitTypingStatus("not-typing");
     } else {
-      const planningPayload = conversationMode === "planning" ? { mode: "plan" } : {};
+      const planningPayload = (isStream && conversationMode === "planning") ? { mode: "plan" } : {};
       sendMessage({ ...messageObj, ...planningPayload });
     }
   }, [isHelloUser, sendMessage, sendMessageToHello, conversationMode]);
@@ -455,7 +456,7 @@ const ChatbotTextField: React.FC<ChatbotTextFieldProps> = ({ className, chatSess
               </div>
               {uploadButton}
 
-              {!isHelloUser && (
+              {!isHelloUser && isStream && (
                 <div className="relative" ref={modeMenuRef}>
                   <button
                     type="button"

--- a/components/Interface-Chatbot/Messages/AssistantMessage.tsx
+++ b/components/Interface-Chatbot/Messages/AssistantMessage.tsx
@@ -6,7 +6,7 @@ import { Anchor, Code } from "@/components/Interface-Chatbot/Interface-Markdown/
 import { supportsLookbehind } from "@/utils/appUtility";
 import { isJSONString } from "@/utils/ChatbotUtility";
 import { useCustomSelector } from "@/utils/deepCheckSelector";
-import { lighten } from "@mui/material";
+import { lighten, useTheme } from "@mui/material";
 import copy from "copy-to-clipboard";
 import { AlertCircle, Check, Copy, Maximize2, ThumbsDown, ThumbsUp } from "lucide-react";
 import dynamic from 'next/dynamic';
@@ -87,6 +87,7 @@ const AssistantMessageCard = React.memo(
             }, 1500);
         };
 
+        const theme = useTheme();
         const themePalette = {
             "--primary-main": lighten(backgroundColor, 0.4),
         };
@@ -193,7 +194,7 @@ const AssistantMessageCard = React.memo(
                                         </div>
                                     ))
                                 ) : (
-                                    <div className="prose dark:prose-invert break-words">
+                                    <div className="prose dark:prose-invert break-words" style={{ color: theme.palette.text.primary }}>
                                         {planning && <PlanningTasksCard plan={planning} isStreaming={message?.isStreaming} onAction={handlePlanningAction} />}
                                         <ReasoningAccordion reasoning={reasoning} isStreaming={message?.isStreaming} hasContent={!!message?.content} />
                                         <ToolCallAccordion toolsData={toolsData} />

--- a/components/Interface-Chatbot/Messages/PlanningTasksCard.tsx
+++ b/components/Interface-Chatbot/Messages/PlanningTasksCard.tsx
@@ -241,7 +241,7 @@ export default function PlanningTasksCard({ plan, isStreaming = false, onAction 
 
                                                 {task.human_query && !isExecuting && (
                                                     <div className="mt-2 space-y-1.5">
-                                                        <div className="flex items-start gap-1.5 text-[11px] text-warning">
+                                                        <div className="flex items-start gap-1.5 text-[11px] text-indigo-600 dark:text-indigo-400">
                                                             <span className="font-semibold shrink-0">?</span>
                                                             <span>{task.human_query}</span>
                                                         </div>


### PR DESCRIPTION
- Add isStream selector to check if 'stream' mode is active
- Conditionally show planning mode toggle only when stream mode is enabled
- Only apply planning payload when both stream mode and planning conversation mode are active
- Apply theme-aware text color to assistant message prose content
- Update human query text color to indigo with dark mode support