### PR TITLE
feat: Add planning state detection from done event content

### DIFF
--- a/components/Chatbot/hooks/useChatActions.ts
+++ b/components/Chatbot/hooks/useChatActions.ts
@@ -430,6 +430,23 @@ export const useSendMessage = ({
                         } else if (isPlanUpdateRequest) {
                             globalDispatch(updatePlanningExecutionState({ executionState: "updated" }));
                         } else {
+                            const doneContent = event?.response?.data?.content;
+                            if (typeof doneContent === "string") {
+                                try {
+                                    const parsed = JSON.parse(doneContent);
+                                    if (parsed?.state === "planning" && parsed?.tasks) {
+                                        globalDispatch(setPlanningData({ plan: parsed }));
+                                        globalDispatch(updateLastAssistantMessage({
+                                            role: "assistant",
+                                            isStreaming: false,
+                                            id: event.message_id,
+                                            finish_reason: event.finish_reason,
+                                            message_id: event.message_id,
+                                        }));
+                                        break;
+                                    }
+                                } catch (_) {}
+                            }
                             globalDispatch(updateLastAssistantMessage({
                                 role: "assistant",
                                 isStreaming: false,


### PR DESCRIPTION
- Parse content from done event to detect planning state
- Set planning data and update assistant message when planning tasks are detected
- Add try-catch to safely handle JSON parsing of done event content
- Break after handling planning state to prevent duplicate message updates