### PR TITLE
fix: add template_response event handling and remove widget mode from…

### DIFF
--- a/components/Chatbot/hooks/useChatActions.ts
+++ b/components/Chatbot/hooks/useChatActions.ts
@@ -223,7 +223,7 @@ export const useSendMessage = ({
             images: imageUrls,
             files,
             userId,
-            flag: Boolean(helloMode?.includes("stream") && !(helloMode?.includes("widget") || helloMode?.includes("image_model"))),
+            flag: Boolean(helloMode?.includes("stream") && !(helloMode?.includes("image_model"))),
             interfaceContextData: { ...variables, ...customVariables } || {},
             threadId: customThreadId || threadId,
             subThreadId: subThreadId,
@@ -405,6 +405,19 @@ export const useSendMessage = ({
                             call_id: event.call_id,
                             content: event.content,
                         }));
+                        break;
+                    case "template_response":
+                        if (timeoutIdRef.current) clearTimeout(timeoutIdRef.current);
+                        globalDispatch(updateLastAssistantMessage({
+                            role: "assistant",
+                            wait: false,
+                            isStreaming: false,
+                            content: event.content,
+                            id: event.message_id,
+                            message_id: event.message_id,
+                            template_metadata: event.metadata || null,
+                        }));
+                        globalDispatch(setLoading(false));
                         break;
                     case "delta":
                         if (isExecutionStreamActive) {

--- a/config/api.ts
+++ b/config/api.ts
@@ -163,6 +163,7 @@ export type StreamEvent =
     | { event: "delta"; content: string }
     | { event: "tool_call"; call_id: string; name: string; args: Record<string, any> }
     | { event: "tool_result"; call_id: string; content: any }
+    | { event: "template_response"; message_id: string; content: any; metadata?: Record<string, any> }
     | { event: "done"; message_id: string; finish_reason: string; usage?: Record<string, any> }
     | { event: "error"; error: string; message_id?: string };
 


### PR DESCRIPTION
… stream flag condition

- Add template_response event case to handle template-based responses
- Update assistant message with template content and metadata on template_response
- Clear timeout and set loading to false when template response is received
- Remove widget mode check from stream flag condition (keep only image_model check)
- Add template_response to StreamEvent type definition with message_id, content, and optional metadata