### PR TITLE
feat: Add review phase support with streaming reviewer analysis and r…

### DIFF
--- a/components/Chatbot/hooks/useChatActions.ts
+++ b/components/Chatbot/hooks/useChatActions.ts
@@ -2,7 +2,7 @@ import { ChatContext } from '@/components/Chatbot-Wrapper/ChatbotWrapper';
 import { errorToast } from '@/components/customToast';
 import { MessageContext } from '@/components/Interface-Chatbot/InterfaceChatbot';
 import { getAllThreadsApi, getPreviousMessage, streamDataToAction, sendFeedbackAction } from '@/config/api';
-import { appendLastAssistantMessageChunk, appendReasoningChunk, appendToolCall, removeMessages, setChatsLoading, setData, setError, setHelloEventMessage, setImages, setInitialMessages, setIsFetching, setLoading, setNewMessage, setOptions, setPaginateMessages, setPlanningData, setStarterQuestions, setToggleDrawer, updateLastAssistantMessage, updatePlanningExecutionState, updateSingleMessage, updateToolResult } from '@/store/chat/chatSlice';
+import { appendLastAssistantMessageChunk, appendReasoningChunk, appendReviewDelta, appendToolCall, removeMessages, setChatsLoading, setData, setError, setHelloEventMessage, setImages, setInitialMessages, setIsFetching, setLoading, setNewMessage, setOptions, setPaginateMessages, setPlanningData, setReviewData, setStarterQuestions, setToggleDrawer, updateLastAssistantMessage, updatePlanningExecutionState, updateSingleMessage, updateToolResult } from '@/store/chat/chatSlice';
 import { setThreads } from '@/store/interface/interfaceSlice';
 import { useCustomSelector } from '@/utils/deepCheckSelector';
 import { PAGE_SIZE } from '@/utils/enums';
@@ -247,6 +247,7 @@ export const useSendMessage = ({
         let isExecutionStreamActive = isPlanExecutionRequest;
         let isExecutionWaitingForUser = false;
         let streamMessageId: string | null = null;
+        let isReviewStreaming = false;
 
         const pushPlanningUpdate = (incoming: any, resetBuffer = false) => {
             if (resetBuffer) {
@@ -459,6 +460,23 @@ export const useSendMessage = ({
                             args: event.args || {},
                         }));
                         break;
+                    case "review_phase":
+                        if (event.phase) {
+                            if (event.phase === "reviewer_start") {
+                                isReviewStreaming = true;
+                            } else if (event.phase === "reviewer_done") {
+                                isReviewStreaming = false;
+                            } else if (event.phase === "main_rerun_start") {
+                                isReviewStreaming = false;
+                            }
+                            globalDispatch(setReviewData({
+                                phase: event.phase,
+                                round: event.round ?? 1,
+                                passed: event.passed,
+                                reason: event.reason || "",
+                            }));
+                        }
+                        break;
                     case "tool_result":
                         globalDispatch(updateToolResult({
                             call_id: event.call_id,
@@ -479,7 +497,9 @@ export const useSendMessage = ({
                         globalDispatch(setLoading(false));
                         break;
                     case "delta":
-                        if (isExecutionStreamActive) {
+                        if (isReviewStreaming) {
+                            globalDispatch(appendReviewDelta({ chunk: event.content || "" }));
+                        } else if (isExecutionStreamActive) {
                             handleExecutionDelta(event.content || "");
                         } else if (isPlanningStreamActive || mode === "plan") {
                             isPlanningStreamActive = true;

--- a/components/Interface-Chatbot/ChatbotTextField.tsx
+++ b/components/Interface-Chatbot/ChatbotTextField.tsx
@@ -10,7 +10,7 @@ import { ParamsEnums } from "@/utils/enums";
 import { isColorLight } from "@/utils/themeUtility";
 import { TextField, useTheme } from "@mui/material";
 import debounce from "lodash.debounce";
-import { ChevronDown, ChevronUp, Paperclip, Send, Smile, TriangleAlert, X, Zap, BrainCircuit } from "lucide-react";
+import { ChevronDown, ChevronUp, Loader2, Paperclip, Send, Smile, TriangleAlert, X, Zap, BrainCircuit } from "lucide-react";
 import Image from "next/image";
 import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { useChatActions, useSendMessage } from "../Chatbot/hooks/useChatActions";
@@ -73,16 +73,18 @@ const ChatbotTextField: React.FC<ChatbotTextFieldProps> = ({ className, chatSess
   const { setImages } = useChatActions();
   const sendMessage = useSendMessage({});
 
-  const { images = [], options = [], loading, error, isPlanExecuting } = useCustomSelector((state) => {
+  const { images = [], options = [], loading, error, isPlanExecuting, isReviewActive } = useCustomSelector((state) => {
     const subThreadId = state.appInfo?.[tabSessionId]?.subThreadId;
     const lastMessageId = subThreadId ? state.Chat?.messageIds?.[subThreadId]?.[0] : null;
     const planningExecState = lastMessageId ? state.Chat?.msgIdAndDataMap?.[subThreadId]?.[lastMessageId]?.planning?.execution?.state : null;
+    const reviewPhases = lastMessageId ? state.Chat?.msgIdAndDataMap?.[subThreadId]?.[lastMessageId]?.review_phases : null;
     return {
       images: state.Chat.images || [],
       loading: state.Chat.loading,
       options: state.Chat.options || [],
       error: state.Chat.error,
       isPlanExecuting: planningExecState === "executing" || planningExecState === "running" || planningExecState === "queued",
+      isReviewActive: Array.isArray(reviewPhases) && reviewPhases.length > 0 && reviewPhases[reviewPhases.length - 1]?.isStreaming === true,
     };
   })
 
@@ -569,8 +571,14 @@ const ChatbotTextField: React.FC<ChatbotTextFieldProps> = ({ className, chatSess
               )}
             </div>
 
-            {/* Right section: Call + Send button side by side */}
+            {/* Right section: under-review indicator + Call + Send button side by side */}
             <div className="flex items-center gap-2">
+              {isReviewActive && (
+                <div className="flex items-center gap-1.5 px-2 py-1 rounded-lg border" style={{ background: "oklch(var(--p) / 0.06)", borderColor: "oklch(var(--p) / 0.2)" }}>
+                  <Loader2 className="w-3 h-3 animate-spin shrink-0" style={{ color: "oklch(var(--p) / 0.7)" }} />
+                  <span className="text-[10px] font-medium" style={{ color: "oklch(var(--p) / 0.7)" }}>Under review…</span>
+                </div>
+              )}
               <CallButton />
               {show_send_button && (
                 <button

--- a/components/Interface-Chatbot/Messages/AssistantMessage.tsx
+++ b/components/Interface-Chatbot/Messages/AssistantMessage.tsx
@@ -17,6 +17,7 @@ import RenderNode from "../../richUI/RenderNode";
 import { componentRegistry } from "../../richUI/componentRegistry";
 import PlanningTasksCard from "./PlanningTasksCard";
 import ReasoningAccordion from "./ReasoningAccordion";
+import ReviewPhaseAccordion from "./ReviewPhaseAccordion";
 import ToolCallAccordion from "./ToolCallAccordion";
 import remarkGfm from 'remark-gfm';
 
@@ -96,6 +97,7 @@ const AssistantMessageCard = React.memo(
         const planning = message?.planning;
         const isPlanningCompleted = planning?.execution?.state === "completed";
         const suppressContent = planning && !isPlanningCompleted;
+        const reviewPhases = Array.isArray(message?.review_phases) ? message.review_phases : [];
 
         const handlePlanningAction = useCallback((action: "proceed" | "respond" | "revise", payload: { parsedPlan: any; rawPlan: string; taskQueries?: Record<string, string>; queryMessage?: string; humanQueryAnswers?: Record<string, string>; humanQueryMessage?: string; resolvedAfter?: boolean; humanQueryAnswersMessage?: string; updateMessage?: string }) => {
             if (action === "respond") {
@@ -199,6 +201,7 @@ const AssistantMessageCard = React.memo(
                                         <ReasoningAccordion reasoning={reasoning} isStreaming={message?.isStreaming} hasContent={!!message?.content} />
                                         {planning && <PlanningTasksCard plan={planning} isStreaming={message?.isStreaming} onAction={handlePlanningAction} />}
                                         <ToolCallAccordion toolsData={toolsData} />
+                                        <ReviewPhaseAccordion reviewPhases={reviewPhases} />
                                         {message?.isStreaming && !message?.content && !suppressContent ? (
                                             <div className="loading-indicator" style={themePalette}>
                                                 <div className="loading-bar"></div>

--- a/components/Interface-Chatbot/Messages/ReviewPhaseAccordion.tsx
+++ b/components/Interface-Chatbot/Messages/ReviewPhaseAccordion.tsx
@@ -1,0 +1,185 @@
+/* eslint-disable */
+import { supportsLookbehind } from "@/utils/appUtility";
+import React, { useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { ChevronDown, ChevronRight, CheckCircle2, FileText, Loader2, RotateCcw, XCircle } from "lucide-react";
+
+interface ReviewPhaseEntry {
+    phase: "reviewer_start" | "reviewer_done" | "main_rerun_start";
+    round: number;
+    isStreaming?: boolean;
+    passed?: boolean;
+    reason?: string;
+    reviewContent?: string;
+    snapshotContent?: string;
+}
+
+interface ReviewPhaseAccordionProps {
+    reviewPhases: ReviewPhaseEntry[];
+}
+
+function ReviewerEntry({ entry }: { entry: ReviewPhaseEntry }) {
+    const [reviewOpen, setReviewOpen] = useState(false);
+    const [snapshotOpen, setSnapshotOpen] = useState(false);
+
+    const isStreaming = entry.isStreaming;
+    const passed = entry.passed;
+    const hasFailed = !isStreaming && passed === false;
+    const hasReviewContent = Boolean(entry.reviewContent?.trim());
+    const hasReason = Boolean(entry.reason?.trim());
+    const hasSnapshot = Boolean(entry.snapshotContent?.trim());
+    const canExpand = !isStreaming && (hasReviewContent || hasReason);
+
+    return (
+        <div className="space-y-1">
+            {/* Reviewer analysis row */}
+            <div
+                className="rounded-lg border overflow-hidden text-sm"
+                style={{ borderColor: hasFailed ? "oklch(var(--er) / 0.3)" : isStreaming ? "oklch(var(--p) / 0.25)" : "oklch(var(--su) / 0.3)" }}
+            >
+                <button
+                    type="button"
+                    className="w-full flex items-center gap-2 px-3 py-2 text-left transition-opacity hover:opacity-80"
+                    style={{
+                        background: hasFailed
+                            ? "oklch(var(--er) / 0.07)"
+                            : isStreaming
+                            ? "oklch(var(--p) / 0.06)"
+                            : "oklch(var(--su) / 0.07)",
+                    }}
+                    onClick={() => canExpand && setReviewOpen((v) => !v)}
+                    disabled={!canExpand}
+                >
+                    {isStreaming ? (
+                        <Loader2 className="w-3.5 h-3.5 animate-spin text-primary shrink-0" />
+                    ) : passed ? (
+                        <CheckCircle2 className="w-3.5 h-3.5 text-success shrink-0" />
+                    ) : (
+                        <XCircle className="w-3.5 h-3.5 text-error shrink-0" />
+                    )}
+
+                    <span className="flex-1 text-xs font-medium">
+                        {isStreaming
+                            ? "Reviewing response…"
+                            : passed
+                            ? "Review passed"
+                            : "Review failed"}
+                    </span>
+
+                    {canExpand && (
+                        <span className="text-[10px] opacity-40 mr-1">Reviewer analysis</span>
+                    )}
+                    {canExpand && (
+                        reviewOpen
+                            ? <ChevronDown className="w-3.5 h-3.5 opacity-40 shrink-0" />
+                            : <ChevronRight className="w-3.5 h-3.5 opacity-40 shrink-0" />
+                    )}
+                </button>
+
+                {canExpand && reviewOpen && (
+                    <div className="px-3 py-2.5 border-t space-y-2"
+                        style={{ borderColor: hasFailed ? "oklch(var(--er) / 0.15)" : "oklch(var(--b3))", background: "oklch(var(--b1))" }}>
+                        {hasReviewContent && (
+                            <div className="prose prose-xs dark:prose-invert max-w-none text-[11.5px] leading-relaxed opacity-75 break-words">
+                                <ReactMarkdown {...(!supportsLookbehind() ? {} : { remarkPlugins: [remarkGfm] })}>
+                                    {entry.reviewContent!}
+                                </ReactMarkdown>
+                                {isStreaming && (
+                                    <span className="inline-block w-1.5 h-3.5 bg-current opacity-60 animate-pulse ml-0.5 align-middle" />
+                                )}
+                            </div>
+                        )}
+                        {!hasReviewContent && isStreaming && (
+                            <div className="flex items-center gap-2 opacity-40">
+                                <Loader2 className="w-3 h-3 animate-spin" />
+                                <span className="text-xs">Analysing…</span>
+                            </div>
+                        )}
+                        {!hasReviewContent && !isStreaming && hasReason && (
+                            <p className="text-[11.5px] leading-relaxed opacity-75 break-words">{entry.reason}</p>
+                        )}
+                    </div>
+                )}
+            </div>
+
+            {/* Outdated response snapshot */}
+            {hasSnapshot && (
+                <div className="rounded-lg border overflow-hidden text-sm" style={{ borderColor: "oklch(var(--wa) / 0.3)" }}>
+                    <button
+                        type="button"
+                        className="w-full flex items-center gap-2 px-3 py-2 text-left transition-opacity hover:opacity-80"
+                        style={{ background: "oklch(var(--wa) / 0.07)" }}
+                        onClick={() => setSnapshotOpen((v) => !v)}
+                    >
+                        <FileText className="w-3.5 h-3.5 shrink-0" style={{ color: "oklch(var(--wa))" }} />
+                        <span className="flex-1 text-xs font-medium opacity-70">Outdated response (round {entry.round})</span>
+                        {snapshotOpen
+                            ? <ChevronDown className="w-3.5 h-3.5 opacity-40 shrink-0" />
+                            : <ChevronRight className="w-3.5 h-3.5 opacity-40 shrink-0" />
+                        }
+                    </button>
+
+                    {snapshotOpen && (
+                        <div className="px-3 py-2.5 border-t"
+                            style={{ borderColor: "oklch(var(--wa) / 0.2)", background: "oklch(var(--b1))" }}>
+                            <div className="prose prose-xs dark:prose-invert max-w-none text-[11.5px] leading-relaxed opacity-60 break-words">
+                                <ReactMarkdown {...(!supportsLookbehind() ? {} : { remarkPlugins: [remarkGfm] })}>
+                                    {entry.snapshotContent!}
+                                </ReactMarkdown>
+                            </div>
+                        </div>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}
+
+function RerunSeparator({ round }: { round: number }) {
+    return (
+        <div className="flex items-center gap-2 my-2">
+            <div className="flex-1 h-px" style={{ background: "oklch(var(--p) / 0.2)" }} />
+            <div className="flex items-center gap-1.5 px-2 py-0.5 rounded-full border"
+                style={{ background: "oklch(var(--p) / 0.06)", borderColor: "oklch(var(--p) / 0.2)" }}>
+                <RotateCcw className="w-3 h-3" style={{ color: "oklch(var(--p) / 0.6)" }} />
+                <span className="text-[10px] font-semibold uppercase tracking-wide" style={{ color: "oklch(var(--p) / 0.6)" }}>
+                    Regenerating · Round {round}
+                </span>
+            </div>
+            <div className="flex-1 h-px" style={{ background: "oklch(var(--p) / 0.2)" }} />
+        </div>
+    );
+}
+
+export default function ReviewPhaseAccordion({ reviewPhases }: ReviewPhaseAccordionProps) {
+    if (!reviewPhases || reviewPhases.length === 0) return null;
+
+    return (
+        <div className="mb-3 w-full not-prose space-y-1" data-testid="chatbot-interface-review-phase-accordion">
+            {/* Top separator marking start of review */}
+            <div className="flex items-center gap-2 mb-1">
+                <div className="flex-1 h-px bg-base-300 dark:bg-base-600" />
+                <div className="flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-base-200 dark:bg-base-700 border border-base-300 dark:border-base-600">
+                    <RotateCcw className="w-3 h-3 opacity-40" />
+                    <span className="text-[10px] font-semibold uppercase tracking-wide opacity-40">Review Phase</span>
+                </div>
+                <div className="flex-1 h-px bg-base-300 dark:bg-base-600" />
+            </div>
+
+            {reviewPhases.map((entry, idx) => {
+                if (entry.phase === "main_rerun_start") {
+                    return <RerunSeparator key={idx} round={entry.round} />;
+                }
+                return <ReviewerEntry key={idx} entry={entry} />;
+            })}
+
+            {/* Bottom separator — marks where the new response begins */}
+            <div className="flex items-center gap-2 mt-1">
+                <div className="flex-1 h-px bg-base-300 dark:bg-base-600" />
+                <span className="text-[10px] font-semibold uppercase tracking-wide opacity-30 px-1">Latest response</span>
+                <div className="flex-1 h-px bg-base-300 dark:bg-base-600" />
+            </div>
+        </div>
+    );
+}

--- a/config/api.ts
+++ b/config/api.ts
@@ -167,7 +167,8 @@ export type StreamEvent =
     | { event: "tool_result"; call_id: string; content: any }
     | { event: "template_response"; message_id: string; content: any; metadata?: Record<string, any> }
     | { event: "done"; message_id: string; finish_reason: string; usage?: Record<string, any> }
-    | { event: "error"; error: string; message_id?: string };
+    | { event: "error"; error: string; message_id?: string }
+    | { event: "review_phase"; phase: string; round?: number; passed?: boolean; reason?: string };
 
 export async function streamDataToAction(
     data: any,

--- a/store/chat/chatReducerV2.ts
+++ b/store/chat/chatReducerV2.ts
@@ -429,6 +429,62 @@ export const chatReducerV2 = {
         }
     },
 
+    setReviewData: (state, action: PayloadAction<{ phase: string; round?: number; passed?: boolean; reason?: string }>) => {
+        const subThreadId = state.subThreadId;
+        if (!subThreadId || !state.messageIds[subThreadId]?.length) return;
+        const lastMessageId = state.messageIds[subThreadId][0];
+        if (!state.msgIdAndDataMap[subThreadId]?.[lastMessageId]) return;
+        const msg = state.msgIdAndDataMap[subThreadId][lastMessageId];
+        const existing: any[] = Array.isArray(msg.review_phases) ? msg.review_phases : [];
+        const { phase, round = 1, passed, reason } = action.payload;
+
+        if (phase === "reviewer_start") {
+            msg.review_phases = [...existing, { phase, round, isStreaming: true, reviewContent: "" }];
+
+        } else if (phase === "reviewer_done") {
+            const updated = [...existing];
+            const idx = updated.findLastIndex?.((r: any) => r.round === round);
+            const targetIdx = idx !== undefined && idx >= 0 ? idx : updated.length - 1;
+            if (updated[targetIdx]) {
+                // Strip any trailing JSON blob (e.g. {"passed":false,"reason":"..."}) from streamed reviewContent
+                let cleanedContent = updated[targetIdx].reviewContent || "";
+                cleanedContent = cleanedContent.replace(/\s*\{[^{}]*"passed"[^{}]*\}\s*$/s, "").trimEnd();
+                updated[targetIdx] = { ...updated[targetIdx], phase: "reviewer_done", passed, reason: reason || "", reviewContent: cleanedContent, isStreaming: false };
+            } else {
+                updated.push({ phase: "reviewer_done", round, passed, reason: reason || "", reviewContent: "", isStreaming: false });
+            }
+            msg.review_phases = updated;
+
+        } else if (phase === "main_rerun_start") {
+            // Snapshot the current content into the last failed review phase, then wipe it
+            const updated = [...existing];
+            const lastFailedIdx = updated.findLastIndex?.((r: any) => r.phase === "reviewer_done" && r.passed === false);
+            if (lastFailedIdx >= 0) {
+                updated[lastFailedIdx] = { ...updated[lastFailedIdx], snapshotContent: msg.content || "" };
+            }
+            msg.review_phases = [...updated, { phase: "main_rerun_start", round, isStreaming: true }];
+            msg.content = "";
+            msg.isOutdated = false;
+        }
+    },
+
+    appendReviewDelta: (state, action: PayloadAction<{ chunk: string }>) => {
+        const subThreadId = state.subThreadId;
+        if (!subThreadId || !state.messageIds[subThreadId]?.length) return;
+        const lastMessageId = state.messageIds[subThreadId][0];
+        const msg = state.msgIdAndDataMap[subThreadId]?.[lastMessageId];
+        if (!msg) return;
+        const phases: any[] = Array.isArray(msg.review_phases) ? msg.review_phases : [];
+        if (phases.length === 0) return;
+        const lastIdx = phases.length - 1;
+        const last = phases[lastIdx];
+        if (last?.isStreaming) {
+            const updated = [...phases];
+            updated[lastIdx] = { ...last, reviewContent: (last.reviewContent || "") + action.payload.chunk };
+            msg.review_phases = updated;
+        }
+    },
+
     setError: (state, action: PayloadAction<string | null>) => {
         state.error = action.payload;
     },

--- a/store/chat/chatSlice.ts
+++ b/store/chat/chatSlice.ts
@@ -43,7 +43,9 @@ export const {
     setPaginateMessages,
     setHelloEventMessage,
     setError,
-    resetState
+    resetState,
+    setReviewData,
+    appendReviewDelta
 } = chatSlice.actions;
 
 export default chatSlice.reducer;


### PR DESCRIPTION
…esponse regeneration

- Add review_phase event handling to track reviewer_start, reviewer_done, and main_rerun_start phases
- Implement ReviewPhaseAccordion component to display review rounds with expandable analysis and outdated response snapshots
- Add isReviewStreaming flag to route delta events to review content during reviewer analysis
- Integrate ReviewPhaseAccordion in AssistantMessage to show review phases above final response
- Add "