### PR TITLE
feat: image generation tool support

### DIFF
--- a/components/Chatbot/hooks/useChatActions.ts
+++ b/components/Chatbot/hooks/useChatActions.ts
@@ -607,7 +607,14 @@ export const useSendMessage = ({
                         const wasPlanningStream = isPlanningStreamActive;
                         finalizePlanningStream();
                         if (timeoutIdRef.current) clearTimeout(timeoutIdRef.current);
-                        
+
+                        // Extract image_urls sent in the done event so they can be
+                        // attached to the assistant message and rendered alongside text.
+                        const doneImageUrls = (event as any)?.response?.data?.image_urls;
+                        const imageUrlsPatch = Array.isArray(doneImageUrls) && doneImageUrls.length > 0
+                            ? { image_urls: doneImageUrls, llm_urls: doneImageUrls }
+                            : {};
+
                         // Clear planning loader flag
                         if (streamMessageId || latestMessageId) {
                             globalDispatch(updateSingleMessage({
@@ -650,7 +657,7 @@ export const useSendMessage = ({
                                     if (targetId) {
                                         globalDispatch(updateSingleMessage({
                                             messageId: targetId,
-                                            data: { isStreaming: false, wait: false, message_id: event.message_id, finish_reason: event.finish_reason },
+                                            data: { isStreaming: false, wait: false, message_id: event.message_id, finish_reason: event.finish_reason, ...imageUrlsPatch },
                                         }));
                                     }
                                 } else {
@@ -668,6 +675,7 @@ export const useSendMessage = ({
                                                 wait: false,
                                                 message_id: event.message_id,
                                                 finish_reason: event.finish_reason,
+                                                ...imageUrlsPatch,
                                             },
                                         }));
                                     }
@@ -685,7 +693,7 @@ export const useSendMessage = ({
                                 if (targetId) {
                                     globalDispatch(updateSingleMessage({
                                         messageId: targetId,
-                                        data: { isStreaming: false, wait: false, message_id: event.message_id, finish_reason: event.finish_reason },
+                                        data: { isStreaming: false, wait: false, message_id: event.message_id, finish_reason: event.finish_reason, ...imageUrlsPatch },
                                     }));
                                 }
                             } else {
@@ -703,6 +711,7 @@ export const useSendMessage = ({
                                             wait: false,
                                             message_id: event.message_id,
                                             finish_reason: event.finish_reason,
+                                            ...imageUrlsPatch,
                                         },
                                     }));
                                 }
@@ -728,6 +737,7 @@ export const useSendMessage = ({
                                         wait: false,
                                         content: "",
                                         finish_reason: event.finish_reason,
+                                        ...imageUrlsPatch,
                                     },
                                 }));
                             }
@@ -741,6 +751,7 @@ export const useSendMessage = ({
                                 id: streamMessageId || event.message_id,
                                 message_id: event.message_id,
                                 finish_reason: event.finish_reason,
+                                ...imageUrlsPatch,
                             }));
                         }
                         globalDispatch(setLoading(false));

--- a/components/Interface-Chatbot/Messages/AssistantMessage.tsx
+++ b/components/Interface-Chatbot/Messages/AssistantMessage.tsx
@@ -181,31 +181,35 @@ const AssistantMessageCard = React.memo(
                                         <AlertCircle className="w-4 h-4" />
                                         <p>Timeout reached. Please try again later.</p>
                                     </div>
-                                ) : message.image_urls?.length > 0 ? (
-                                    message?.image_urls?.map((image: any) => (
-                                        <div className="space-y-2" key={image}>
-                                            <ImageWithFallback
-                                                src={image?.image_url || image?.permanent_url}
-                                                permanentUrl={image?.permanent_url}
-                                                alt="Loading image, please wait..."
-                                                width={400}
-                                                height={400}
-                                                loading="lazy"
-                                                className="w-full max-h-[400px] min-h-[100px] rounded-lg object-cover"
-                                            />
-                                            <a
-                                                href={image?.image_url || image?.permanent_url}
-                                                target="_blank"
-                                                rel="noopener noreferrer"
-                                                className="btn btn-ghost btn-sm w-full text-primary flex items-center justify-center"
-                                            >
-                                                <Maximize2 className="w-4 h-4 mr-2" />
-                                                View Full Image
-                                            </a>
-                                        </div>
-                                    ))
                                 ) : (
-                                    <div className="prose dark:prose-invert break-words" style={{ color: theme.palette.text.primary }}>
+                                    <>
+                                        {message?.image_urls?.length > 0 && (
+                                            <div className="space-y-3 mb-3">
+                                                {message?.image_urls?.map((image: any, idx: number) => (
+                                                    <div className="space-y-2" key={image?.image_url || image?.permanent_url || idx}>
+                                                        <ImageWithFallback
+                                                            src={image?.image_url || image?.permanent_url}
+                                                            permanentUrl={image?.permanent_url}
+                                                            alt="Loading image, please wait..."
+                                                            width={400}
+                                                            height={400}
+                                                            loading="lazy"
+                                                            className="w-full max-h-[400px] min-h-[100px] rounded-lg object-cover"
+                                                        />
+                                                        <a
+                                                            href={image?.image_url || image?.permanent_url}
+                                                            target="_blank"
+                                                            rel="noopener noreferrer"
+                                                            className="btn btn-ghost btn-sm w-full text-primary flex items-center justify-center"
+                                                        >
+                                                            <Maximize2 className="w-4 h-4 mr-2" />
+                                                            View Full Image
+                                                        </a>
+                                                    </div>
+                                                ))}
+                                            </div>
+                                        )}
+                                        <div className="prose dark:prose-invert break-words" style={{ color: theme.palette.text.primary }}>
                                         {planning ? (
                                             <WorkingAccordion
                                                 reasoning={reasoning}
@@ -376,7 +380,8 @@ const AssistantMessageCard = React.memo(
                                                 </ReactMarkdown>
                                             );
                                         })()}
-                                    </div>
+                                        </div>
+                                    </>
                                 )}
                             </div>
                         )}

--- a/config/api.ts
+++ b/config/api.ts
@@ -166,7 +166,7 @@ export type StreamEvent =
     | { event: "tool_call"; call_id: string; name: string; args: Record<string, any> }
     | { event: "tool_result"; call_id: string; content: any }
     | { event: "template_response"; message_id: string; content: any; metadata?: Record<string, any> }
-    | { event: "done"; message_id: string; finish_reason: string; usage?: Record<string, any> }
+    | { event: "done"; message_id: string; finish_reason: string; usage?: Record<string, any>; response?: { data?: { content?: string; image_urls?: any[]; [key: string]: any }; [key: string]: any } }
     | { event: "error"; error: string; message_id?: string }
     | { event: "review_phase"; phase: string; round?: number; passed?: boolean; reason?: string };
 


### PR DESCRIPTION
# Image generation tool support

Render LLM-returned `image_urls` alongside text in assistant messages, including those delivered via the SSE `done` event.

## Changes

- **[AssistantMessage.tsx](cci:7://file:///c:/Users/adity/Documents/gtwy-python/chatbot/chatbot-ui/components/Interface-Chatbot/Messages/AssistantMessage.tsx:0:0-0:0)** — replaced the mutually-exclusive image-vs-text branch with an additive layout: images render above the markdown/reasoning/tool/planning content whenever `image_urls` is non-empty.
- **[useChatActions.ts](cci:7://file:///c:/Users/adity/Documents/gtwy-python/chatbot/chatbot-ui/components/Chatbot/hooks/useChatActions.ts:0:0-0:0)** — in the `done` handler, extract `image_urls` from `event.response.data.image_urls` and merge them onto the assistant message in redux across all done branches.
- **[api.ts](cci:7://file:///c:/Users/adity/Documents/gtwy-python/chatbot/chatbot-ui/config/api.ts:0:0-0:0)** — extended the `done` [StreamEvent](cci:2://file:///c:/Users/adity/Documents/gtwy-python/chatbot/chatbot-ui/config/api.ts:157:0-170:98) type with the `response.data.image_urls` shape.

## Behavior

- Text-only and image-only responses render exactly as before.
- Combined responses now show both images and text in the same message.