### PR TITLE
bug: image compression fixed

### DIFF
--- a/components/Interface-Chatbot/ChatbotTextField.tsx
+++ b/components/Interface-Chatbot/ChatbotTextField.tsx
@@ -287,11 +287,11 @@ const ChatbotTextField: React.FC<ChatbotTextFieldProps> = ({ className, chatSess
       <div className="flex flex-wrap gap-3 my-4 px-4">
         {images.map((image, index) => (
           <div key={index} className="relative group">
-            <div className="w-24 h-24 md:w-32 md:h-32 rounded-lg overflow-hidden shadow-md transition-transform hover:scale-105">
+            <div className="w-24 h-24 md:w-32 md:h-32 rounded-lg overflow-hidden shadow-md bg-base-200 transition-transform hover:scale-105">
               <ImageWithFallback
                 src={image}
                 alt={`Uploaded Preview ${index + 1}`}
-                style={{ width: 128, height: 128 }}
+                style={{ width: "100%", height: "100%" }}
                 canDownload={false}
                 preview={true}
               />

--- a/components/Interface-Chatbot/Messages/AssistantMessage.tsx
+++ b/components/Interface-Chatbot/Messages/AssistantMessage.tsx
@@ -200,10 +200,7 @@ const AssistantMessageCard = React.memo(
                                                             src={image?.image_url || image?.permanent_url}
                                                             permanentUrl={image?.permanent_url}
                                                             alt="Loading image, please wait..."
-                                                            width={400}
-                                                            height={400}
-                                                            loading="lazy"
-                                                            className="w-full max-h-[400px] min-h-[100px] rounded-lg object-cover"
+                                                            className="w-full max-h-[400px] rounded-lg object-contain"
                                                         />
                                                         <a
                                                             href={image?.image_url || image?.permanent_url}

--- a/components/Interface-Chatbot/Messages/ImageWithFallback.tsx
+++ b/components/Interface-Chatbot/Messages/ImageWithFallback.tsx
@@ -9,6 +9,7 @@ type ImageWithFallbackProps = {
   permanentUrl?: string;
   alt?: string;
   style?: React.CSSProperties;
+  className?: string;
   canDownload?: boolean;
   preview?: boolean;
 };
@@ -82,6 +83,7 @@ const ImageWithFallback = ({
   permanentUrl,
   alt = "attachment",
   style,
+  className = "",
   canDownload = true,
   preview = false
 }: ImageWithFallbackProps) => {
@@ -135,11 +137,20 @@ const ImageWithFallback = ({
     }, "*");
   }, [currentSrc]);
 
-  // Memoized container classes
-  const containerClasses = useMemo(() =>
-    `flex relative group ${isSmallScreen ? 'max-w-[80%]' : 'max-w-[40%]'} h-auto rounded-md cursor-pointer hover:opacity-90 transition-opacity`,
-    [isSmallScreen]
-  );
+  // Preview thumbs fill their parent; message images keep natural aspect with a larger cap
+  const containerClasses = useMemo(() => {
+    if (preview) {
+      return "flex relative group w-full h-full rounded-md overflow-hidden";
+    }
+    return `flex relative group ${isSmallScreen ? "max-w-[85%]" : "max-w-[70%]"} h-auto rounded-md cursor-pointer hover:opacity-90 transition-opacity`;
+  }, [isSmallScreen, preview]);
+
+  const imageClasses = useMemo(() => {
+    if (preview) {
+      return `w-full h-full object-contain ${className}`.trim();
+    }
+    return `max-w-full h-auto max-h-[480px] object-contain rounded-md ${className}`.trim();
+  }, [preview, className]);
 
   const renderContent = useCallback(() => {
     if (error) return <ErrorDisplay />;
@@ -152,6 +163,7 @@ const ImageWithFallback = ({
             alt={alt}
             onError={handleError}
             onClick={handleClick}
+            className={imageClasses}
             style={style}
             data-testid="chatbot-message-image"
           />
@@ -160,13 +172,13 @@ const ImageWithFallback = ({
       case "video":
         return preview ? (
           <div
-            className="max-w-full rounded-md relative"
+            className="max-w-full rounded-md relative w-full h-full"
             style={style}
             onClick={handleClick}
             data-testid="chatbot-message-video-preview"
           >
             <video
-              className="w-full h-full object-cover rounded-md"
+              className="w-full h-full object-contain rounded-md"
               onError={handleError}
             >
               <source src={currentSrc} type={videoType} />
@@ -224,12 +236,13 @@ const ImageWithFallback = ({
             alt={alt}
             onError={handleError}
             onClick={handleClick}
+            className={imageClasses}
             style={style}
             data-testid="chatbot-message-file"
           />
         );
     }
-  }, [error, fileType, currentSrc, alt, style, preview, handleError, handleClick, videoType, audioType]);
+  }, [error, fileType, currentSrc, alt, style, preview, handleError, handleClick, videoType, audioType, imageClasses]);
 
   return (
     <div className={containerClasses} data-testid="chatbot-image-container">


### PR DESCRIPTION
ImageWithFallback — raised message max width from 40% → 70%, keep natural aspect with object-contain, support className
Upload preview — no more forced 128×128 stretch; uses object-contain inside the thumb box
Assistant images — className now applies (was ignored before); uses object-contain instead of cover/crop