### PR TITLE
new chat issue fixed

### DIFF
--- a/components/Interface-Chatbot/ChatbotDrawerParts/Sidebar.tsx
+++ b/components/Interface-Chatbot/ChatbotDrawerParts/Sidebar.tsx
@@ -73,9 +73,27 @@ const SidebarDefault = ({
     }
   };
 
+  const handleChangeSubThread = (sub_thread_id: string) => {
+    setLoading(false);
+    dispatch(setDataInAppInfoReducer({ subThreadId: sub_thread_id }));
+    setNewMessage(true);
+    setOptions([]);
+    focusTextField();
+    if (isSmallScreen) setToggleDrawer(false);
+  };
+
   const handleCreateNewSubThread = () => {
     if (preview) return;
-    if (subThreadList?.[0]?.newChat) return;
+    // Reuse the unused empty "New Chat" instead of creating another / no-op
+    if (subThreadList?.[0]?.newChat) {
+      const emptySubThreadId = subThreadList[0].sub_thread_id;
+      if (subThreadId !== emptySubThreadId) {
+        handleChangeSubThread(emptySubThreadId);
+      } else {
+        focusTextField();
+      }
+      return;
+    }
     const newThreadData = {
       sub_thread_id: createRandomId(),
       thread_id: threadId,
@@ -84,15 +102,6 @@ const SidebarDefault = ({
     };
     dispatch(setThreads({ newThreadData, bridgeName, threadId } as any));
     setOptions([]);
-  };
-
-  const handleChangeSubThread = (sub_thread_id: string) => {
-    setLoading(false);
-    dispatch(setDataInAppInfoReducer({ subThreadId: sub_thread_id }));
-    setNewMessage(true);
-    setOptions([]);
-    focusTextField();
-    if (isSmallScreen) setToggleDrawer(false);
   };
 
   const closeToggleDrawer = (isOpen: boolean) => setToggleDrawer(isOpen);

--- a/components/Interface-Chatbot/ChatbotHeader.tsx
+++ b/components/Interface-Chatbot/ChatbotHeader.tsx
@@ -393,7 +393,7 @@ const ChatbotHeader: React.FC<ChatbotHeaderProps> = ({ preview = false, chatSess
     setToggleDrawer,
   } = useChatActions();
 
-  const { isToggledrawer, bridgeName: reduxBridgeName, headerButtons, messageIds, lastMessage, isChatbotMinimized } = useCustomSelector((state) => ({
+  const { isToggledrawer, bridgeName: reduxBridgeName, headerButtons, messageIds, lastMessage, isChatbotMinimized, currentSubThreadId } = useCustomSelector((state) => ({
     isToggledrawer: state.Chat?.isToggledrawer,
     bridgeName: state.Chat.bridgeName || [],
     headerButtons: state.Chat?.headerButtons || [],
@@ -402,7 +402,8 @@ const ChatbotHeader: React.FC<ChatbotHeaderProps> = ({ preview = false, chatSess
       const lastMessageId = state.Chat?.messageIds?.[currentChannelId]?.[0]
       return state.Chat?.msgIdAndDataMap?.[currentChannelId]?.[lastMessageId]
     })(),
-    isChatbotMinimized: state.draftData?.isChatbotMinimized || false
+    isChatbotMinimized: state.draftData?.isChatbotMinimized || false,
+    currentSubThreadId: state.appInfo?.[tabSessionId]?.subThreadId || state.Chat?.subThreadId,
   }))
 
   const { chatbotConfig } = useContext<any>(ChatbotContext);
@@ -452,7 +453,13 @@ const ChatbotHeader: React.FC<ChatbotHeaderProps> = ({ preview = false, chatSess
   // Handler for creating a new thread
   const handleCreateNewSubThread = async () => {
     if (preview) return;
+    // Reuse the unused empty "New Chat" instead of creating another / no-op
     if (subThreadList?.[0]?.newChat) {
+      const emptySubThreadId = subThreadList[0].sub_thread_id;
+      if (currentSubThreadId !== emptySubThreadId) {
+        dispatch(setDataInAppInfoReducer({ subThreadId: emptySubThreadId }));
+        setOptions([]);
+      }
       return;
     }
 
@@ -463,16 +470,14 @@ const ChatbotHeader: React.FC<ChatbotHeaderProps> = ({ preview = false, chatSess
       newChat: true
     }
 
-    if (!subThreadList?.[0]?.newChat) {
-      dispatch(
-        setThreads({
-          newThreadData,
-          bridgeName: reduxBridgeName,
-          threadId: threadId,
-        })
-      );
-      setOptions([]);
-    }
+    dispatch(
+      setThreads({
+        newThreadData,
+        bridgeName: reduxBridgeName,
+        threadId: threadId,
+      })
+    );
+    setOptions([]);
   };
 
   // Handle fullscreen toggle


### PR DESCRIPTION
1. Sidebar.tsx (drawer New Chat button)

Instead of a bare return, if an empty New Chat already exists:

If you’re not on it → call handleChangeSubThread(emptyId) (same as clicking that thread in the list)
If you are already on it → just focus the text field
Only if no empty New Chat exists → create a new one as before

2. ChatbotHeader.tsx (header New Chat when drawer is closed)

Same idea: if empty New Chat exists, set subThreadId to that id instead of returning and doing nothing.

Also pulled currentSubThreadId from Redux so we can tell if you’re already on that empty chat.